### PR TITLE
change landing page and migrate create user logic

### DIFF
--- a/src/app/(dashboard)/home/page.tsx
+++ b/src/app/(dashboard)/home/page.tsx
@@ -1,5 +1,45 @@
-export default function Page() {
+'use client';
+
+import React, { Suspense, useEffect, useState } from 'react';
+import createUser from '@/data-access/users/create-user';
+import getUser from '@/data-access/users/get-user';
+import { BookUser } from '@/types/user';
+import { useUser } from '@clerk/nextjs';
+
+export default function Home() {
+  const { isSignedIn, user } = useUser();
+  const [_, setLoggedInUser] = useState<BookUser | null>(null);
+
+  useEffect(() => {
+    if (isSignedIn) {
+      const fetchData = async () => {
+        try {
+          const pushdata: BookUser = {
+            id: user.id,
+            firstname: user.firstName ?? '',
+            lastname: user.lastName ?? '',
+            email: user.emailAddresses[0].emailAddress,
+            username: user.username ?? user.emailAddresses[0].emailAddress,
+            clerkid: user.id,
+            createdAt: user.createdAt,
+            updatedAt: user.updatedAt,
+          };
+
+          await createUser(pushdata);
+          const fetchedUser = await getUser();
+          setLoggedInUser(fetchedUser ?? null);
+        } catch (error) {
+          console.error('Error in user operations:', error);
+        }
+      };
+
+      fetchData();
+    }
+  }, [isSignedIn, user]);
+
   <div className='flex justify-center items-center h-screen'>
-    <h2 className='text-center'>This will be the new homepage</h2>
+    <Suspense fallback='Loading...'>
+      <h2 className='text-center'>This will be the new homepage</h2>
+    </Suspense>
   </div>;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,59 +1,15 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import createUser from '@/data-access/users/create-user';
-import getUser from '@/data-access/users/get-user';
-import { BookUser } from '@/types/user';
 import { useUser } from '@clerk/nextjs';
 import { redirect } from 'next/navigation';
 
 export default function Home() {
-  const { isLoaded, isSignedIn, user } = useUser();
-  const [loggedInUser, setLoggedInUser] = useState<BookUser | null>(null);
-
-  useEffect(() => {
-    if (user) {
-      const pushdata: BookUser = {
-        id: user.id,
-        firstname: user.firstName ?? '',
-        lastname: user.lastName ?? '',
-        email: user.emailAddresses[0].emailAddress,
-        username: user.username ?? user.emailAddresses[0].emailAddress,
-        clerkid: user.id,
-        createdAt: user.createdAt,
-        updatedAt: user.updatedAt,
-      };
-
-      const createUserAndFetch = async () => {
-        try {
-          await createUser(pushdata);
-          const fetchedUser = await getUser();
-          setLoggedInUser(fetchedUser ?? null);
-        } catch (error) {
-          console.error('Error in user operations:', error);
-        }
-      };
-
-      createUserAndFetch();
-    }
-  }, [user]);
-
-  if (!isLoaded) {
-    return (
-      <main>
-        <h1>Loading...</h1>
-      </main>
-    );
-  }
+  const { isSignedIn, user } = useUser();
 
   if (!isSignedIn || !user) {
-    return (
-      <main>
-        <h1>Please sign in</h1>
-      </main>
-    );
+    return redirect('/sign-in');
   }
 
-  // Render logged-in user's information
+  // Redirect to dashboard
   return redirect('/home');
 }

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -3,7 +3,7 @@ import { SignIn } from '@clerk/nextjs';
 export default function Page() {
   return (
     <div className='flex items-center justify-center min-h-screen'>
-      <SignIn />
+      <SignIn afterSignInUrl={'/home'} />
     </div>
   );
 }

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -3,7 +3,7 @@ import { SignUp } from '@clerk/nextjs';
 export default function Page() {
   return (
     <div className='flex items-center justify-center min-h-screen'>
-      <SignUp afterSignUpUrl={'/'} />
+      <SignUp afterSignUpUrl={'/home'} />
     </div>
   );
 }


### PR DESCRIPTION
Work done:
- Landing page now only checks for user and redirects to either sign-in (if not logged in) or dashboard if logged-in.
- Added path for succesuful sign-in/up pages
- Changed a few things around your create user logic function and moved it to the dashboard
- Tested that redirects are working and users are being created on db
- We still need to move logic away from the page